### PR TITLE
fixed type parameters for auto-completion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import { Context, Next, Handler } from 'hono'
+import { Handler } from 'hono'
 
 export const hello = (message: string = 'Hello'): Handler => {
-  return async (c: Context, next: Next) => {
+  return async (c, next) => {
     await next()
     c.res.headers.append('X-Message', message)
   }


### PR DESCRIPTION
Currently, if a type is specified in the Handler, the specified type parameter is not reflected. For example

```ts
export const hello = (message: string = 'Hello'): Handler<string, MyEnv> => {
  // Context does have a default Env instead of MyEnv.
  return async (c: Context, next: Next) => {
```

We expect MyEnv here, so I fixed it so that its auto-completion works.